### PR TITLE
cli-gh-cal 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![cli-gh-cal](http://i.imgur.com/pw82kYP.png)](#)
 
-# `$ cli-gh-cal` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/cli-gh-cal.svg)](https://travis-ci.org/IonicaBizau/cli-gh-cal/) [![Version](https://img.shields.io/npm/v/cli-gh-cal.svg)](https://www.npmjs.com/package/cli-gh-cal) [![Downloads](https://img.shields.io/npm/dt/cli-gh-cal.svg)](https://www.npmjs.com/package/cli-gh-cal) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# `$ cli-gh-cal`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Travis](https://img.shields.io/travis/IonicaBizau/cli-gh-cal.svg)](https://travis-ci.org/IonicaBizau/cli-gh-cal/) [![Version](https://img.shields.io/npm/v/cli-gh-cal.svg)](https://www.npmjs.com/package/cli-gh-cal) [![Downloads](https://img.shields.io/npm/dt/cli-gh-cal.svg)](https://www.npmjs.com/package/cli-gh-cal) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > GitHub like calendar graphs in command line.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-gh-cal",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "GitHub like calendar graphs in command line.",
   "main": "lib/index.js",
   "directories": {
@@ -52,6 +52,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.