### PR TITLE
Use <window-size> for terminal width

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ const Moment = require("moment")
     , CliBox = require("cli-box")
     , AnsiParser = require("ansi-parser")
     , Deffy = require("deffy")
-    , cliSize = require("cli-size")
     ;
 
 // Configs
@@ -67,7 +66,7 @@ const DATE_FORMAT = "MMM D, YYYY"
  */
 function CliGhCal(data, options) {
 
-    var CLI_COLUMNS = cliSize().columns;
+    var CLI_COLUMNS = require('window-size').width;
     var cal = {
         total: 0
       , days: {}
@@ -79,7 +78,7 @@ function CliGhCal(data, options) {
     }
 
     if (options.noCrop === undefined) {
-        options.noCrop = !!options.raw || !process.stdout.isTTY;
+        options.noCrop = !!options.raw;
     }
 
     // Convert input data dates into Moment

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     "ansi-parser": "^3.0.0",
     "bug-killer": "^4.2.5",
     "cli-box": "^6.0.5",
-    "cli-size": "^1.0.3",
     "couleurs": "^6.0.5",
     "deffy": "^2.0.0",
     "git-stats-colors": "^2.3.8",
     "moment": "^2.9.0",
     "tilda": "^4.3.3",
     "typpy": "^2.0.0",
-    "ul": "^5.0.0"
+    "ul": "^5.0.0",
+    "window-size": "^1.1.1"
   },
   "devDependencies": {},
   "files": [


### PR DESCRIPTION
I'm a big fan of `git-stats`, but it has been bugging me that `git-stats` loses terminal rows and columns when piped to `less`. See below.
<img width="1049" alt="demo" src="https://user-images.githubusercontent.com/9512759/47570023-f12c6c00-d8e9-11e8-908b-1b8a695a1943.png">


After a bit of research, I figured that it has to do with node doesn't handle well with `less` and `more`, so I recommend using `window-size` to tell the terminal width when dealing with piping. `window-size` deals with many edge cases of outputting, because it runs tput underneath as a last resort.